### PR TITLE
Add basic authentication router

### DIFF
--- a/carsharing.py
+++ b/carsharing.py
@@ -1,7 +1,7 @@
 import uvicorn
 from db import engine
 from sqlmodel import SQLModel
-from routers import cars, web
+from routers import cars, web, auth
 from routers.cars import BadTripException
 from contextlib import asynccontextmanager
 from fastapi.responses import JSONResponse
@@ -14,8 +14,9 @@ async def lifespan(app: FastAPI):
     yield
 
 app = FastAPI(title="Car Sharing API", lifespan=lifespan)
-app.include_router(cars.router) 
+app.include_router(cars.router)
 app.include_router(web.router)
+app.include_router(auth.router)
 
 origins = [
     "http://localhost:8000",

--- a/create_user.py
+++ b/create_user.py
@@ -13,7 +13,7 @@ from schemas import User
 logging.getLogger('passlib').setLevel(logging.ERROR)
 
 engine = create_engine(
-    "sqlite:///carsharing.db",
+    "sqlite:///cars.db",
     connect_args={"check_same_thread": False},  # Needed for SQLite
     echo=True # Log generated SQL
 )

--- a/routers/__init__.py
+++ b/routers/__init__.py
@@ -1,0 +1,7 @@
+from . import cars, web, auth
+
+__all__ = [
+    "cars",
+    "web",
+    "auth",
+]

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,0 +1,56 @@
+from typing import Annotated, Dict
+import secrets
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from sqlmodel import Session, select
+
+from db import get_session
+from schemas import User, UserOutput, UserCreate
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+_tokens: Dict[str, int] = {}
+
+@router.post("/register", response_model=UserOutput)
+def register(user_in: UserCreate, session: Annotated[Session, Depends(get_session)]):
+    user = User(username=user_in.username)
+    user.set_password(user_in.password)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+@router.post("/login")
+def login(
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
+    session: Annotated[Session, Depends(get_session)],
+):
+    query = select(User).where(User.username == form_data.username)
+    user = session.exec(query).first()
+    if not user or not user.verify_password(form_data.password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid username or password",
+        )
+    token = secrets.token_urlsafe(32)
+    _tokens[token] = user.id
+    return {"access_token": token, "token_type": "bearer"}
+
+def get_current_user(
+    token: Annotated[str, Depends(oauth2_scheme)],
+    session: Annotated[Session, Depends(get_session)],
+) -> User:
+    user_id = _tokens.get(token)
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    user = session.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    return user
+
+@router.get("/me", response_model=UserOutput)
+def read_me(current_user: Annotated[User, Depends(get_current_user)]):
+    return current_user

--- a/schemas.py
+++ b/schemas.py
@@ -7,6 +7,10 @@ class UserOutput(SQLModel):
     id: int
     username: str
 
+class UserCreate(SQLModel):
+    username: str
+    password: str
+
 class User(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     username: str = Field(sa_column=Column("username", VARCHAR, unique=True, index=True))


### PR DESCRIPTION
## Summary
- provide a new `/auth` router with register and login endpoints
- expose a `/auth/me` endpoint for retrieving the current user
- include the new router in the FastAPI app
- unify database path in `create_user.py`
- export routers from `routers/__init__.py`
- add `UserCreate` model to schemas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544de9ef288323bb0fb99e7db8013b